### PR TITLE
修正 无法引用工程里的global.lua

### DIFF
--- a/EmmyLua/CodeAnalysis/Compilation/Analyzer/DeclarationAnalyzer/DeclarationWalker/TagDocWalker.cs
+++ b/EmmyLua/CodeAnalysis/Compilation/Analyzer/DeclarationAnalyzer/DeclarationWalker/TagDocWalker.cs
@@ -171,6 +171,17 @@ public partial class DeclarationWalker
         if (moduleSyntax.Module is { Value: { } moduleName })
         {
             Compilation.Workspace.ModuleManager.AddVirtualModule(DocumentId, moduleName);
+        } else {
+            if (moduleSyntax.Parent!=null)
+            {
+                var childs = moduleSyntax.Parent.ChildrenWithTokens.OfType<LuaNameToken>();
+                foreach (var child in childs)
+                {
+                    if (child.RepresentText == "no-require") {
+                        Compilation.Workspace.ModuleManager.RemoveDocument(DocumentId);
+                    }
+                }
+            }
         }
     }
 

--- a/EmmyLua/CodeAnalysis/Workspace/Module/ModuleManager.cs
+++ b/EmmyLua/CodeAnalysis/Workspace/Module/ModuleManager.cs
@@ -124,6 +124,15 @@ public class ModuleManager
         AddDocument(root, workspace, document);
     }
 
+    public void RemoveDocument(LuaDocumentId documentId)
+    {
+        var document = Workspace.GetDocument(documentId);
+        if (document != null)
+        {
+            RemoveDocument(document);
+        }
+    }
+
     public void RemoveDocument(LuaDocument document)
     {
         if (!DocumentIndex.TryGetValue(document.Id, out var moduleIndex))

--- a/EmmyLua/Resources/std/global.lua
+++ b/EmmyLua/Resources/std/global.lua
@@ -13,6 +13,8 @@
 -- License for the specific language governing permissions and limitations under
 -- the License.
 
+---@module no-require
+
 ---
 --- Calls error if the value of its argument `v` is false (i.e., **nil** or
 --- **false**); otherwise, returns all its arguments. In case of error,


### PR DESCRIPTION
如果工程里根目录有global.lua, 解析的时候会先找到std里的global.lua, 导致错误。
把std里的改名才行