### PR TITLE
Feat/ignore globs

### DIFF
--- a/EmmyLua/CodeAnalysis/Workspace/LuaFeatures.cs
+++ b/EmmyLua/CodeAnalysis/Workspace/LuaFeatures.cs
@@ -2,6 +2,7 @@
 using EmmyLua.CodeAnalysis.Diagnostics;
 using EmmyLua.CodeAnalysis.Document;
 using EmmyLua.CodeAnalysis.Document.Version;
+using GlobExpressions;
 
 namespace EmmyLua.CodeAnalysis.Workspace;
 
@@ -29,7 +30,7 @@ public class LuaFeatures
         ".p4",
     ];
 
-    public HashSet<string> ExcludeFiles { get; set; } = [];
+    public List<Glob> ExcludeGlobs { get; set; } = [];
 
     public List<string> RequirePattern { get; set; } =
     [

--- a/EmmyLua/CodeAnalysis/Workspace/LuaFeatures.cs
+++ b/EmmyLua/CodeAnalysis/Workspace/LuaFeatures.cs
@@ -29,6 +29,8 @@ public class LuaFeatures
         ".p4",
     ];
 
+    public HashSet<string> ExcludeFiles { get; set; } = [];
+
     public List<string> RequirePattern { get; set; } =
     [
         "?/init.lua",

--- a/EmmyLua/CodeAnalysis/Workspace/LuaWorkspace.cs
+++ b/EmmyLua/CodeAnalysis/Workspace/LuaWorkspace.cs
@@ -107,10 +107,12 @@ public class LuaWorkspace
             .Select(it => Path.Combine(directory, it.Trim('\\', '/')))
             .Select(Path.GetFullPath)
             .ToList();
+        var excludeFiles = Features.ExcludeFiles.ToList();
         return Features.Extensions
             .SelectMany(it => Directory.GetFiles(directory, it, SearchOption.AllDirectories))
             .Select(Path.GetFullPath)
-            .Where(file => !excludeFolders.Any(filter => file.StartsWith(filter, StringComparison.OrdinalIgnoreCase)));
+            .Where(file => !excludeFolders.Any(filter => file.StartsWith(filter, StringComparison.OrdinalIgnoreCase)))
+            .Where(file => !excludeFiles.Contains(Path.GetFileName(file), StringComparer.OrdinalIgnoreCase));
     }
 
     /// this will load all third libraries and workspace files

--- a/EmmyLua/CodeAnalysis/Workspace/LuaWorkspace.cs
+++ b/EmmyLua/CodeAnalysis/Workspace/LuaWorkspace.cs
@@ -110,12 +110,12 @@ public class LuaWorkspace
         if (useIgnore)
         {
             var excludeFolders = Features.ExcludeFolders
-                .Select(it => Path.Combine(directory, it.Trim('\\', '/')))
+                .Select(it => Path.Combine(directory, it))
                 .Select(Path.GetFullPath)
                 .ToList();
-            var excludeFiles = Features.ExcludeFiles.ToList();
+            var excludeGlobs = Features.ExcludeGlobs;
             files = files.Where(file => !excludeFolders.Any(filter => file.StartsWith(filter, StringComparison.OrdinalIgnoreCase)))
-                .Where(file => !excludeFiles.Contains(Path.GetFileName(file), StringComparer.OrdinalIgnoreCase));
+                .Where(file => !excludeGlobs.Any(glob => glob.IsMatch(Path.GetRelativePath(directory, file))));
         }
         return files;
     }

--- a/EmmyLua/Configuration/ConfigSchema.cs
+++ b/EmmyLua/Configuration/ConfigSchema.cs
@@ -216,9 +216,8 @@ public class Workspace
         ".vscode"
     ];
 
-    [JsonProperty("ignoreFiles", Required = Required.Default,
-        NullValueHandling = NullValueHandling.Ignore)]
-    public List<string> IgnoreFiles { get; set; } = [];
+    [JsonPropertyName("ignoreGlobs")]
+    public List<string> IgnoreGlobs { get; set; } = [];
 
     [JsonPropertyName("library")]
     public List<string> Library { get; set; } = [];

--- a/EmmyLua/Configuration/ConfigSchema.cs
+++ b/EmmyLua/Configuration/ConfigSchema.cs
@@ -216,6 +216,10 @@ public class Workspace
         ".vscode"
     ];
 
+    [JsonProperty("ignoreFiles", Required = Required.Default,
+        NullValueHandling = NullValueHandling.Ignore)]
+    public List<string> IgnoreFiles { get; set; } = [];
+
     [JsonPropertyName("library")]
     public List<string> Library { get; set; } = [];
 

--- a/EmmyLua/Configuration/SettingManager.cs
+++ b/EmmyLua/Configuration/SettingManager.cs
@@ -7,6 +7,7 @@ using EmmyLua.CodeAnalysis.Document;
 using EmmyLua.CodeAnalysis.Document.Version;
 using EmmyLua.CodeAnalysis.Workspace;
 using EmmyLua.CodeAnalysis.Workspace.Module.FilenameConverter;
+using GlobExpressions;
 
 
 namespace EmmyLua.Configuration;
@@ -145,8 +146,8 @@ public class SettingManager
     {
         var features = new LuaFeatures();
         var setting = Setting;
-        features.ExcludeFolders.UnionWith(setting.Workspace.IgnoreDir);
-        features.ExcludeFiles.UnionWith(setting.Workspace.IgnoreFiles);
+        setting.Workspace.IgnoreDir.ForEach(s => features.ExcludeFolders.Add(s.Trim('\\', '/')));
+        setting.Workspace.IgnoreGlobs.ForEach(s => features.ExcludeGlobs.Add(new Glob(s.TrimStart('\\', '/'))));
         features.DontIndexMaxFileSize = setting.Workspace.PreloadFileSize;
         features.ThirdPartyRoots.AddRange(setting.Workspace.Library);
         features.WorkspaceRoots.AddRange(setting.Workspace.WorkspaceRoots);

--- a/EmmyLua/Configuration/SettingManager.cs
+++ b/EmmyLua/Configuration/SettingManager.cs
@@ -146,6 +146,7 @@ public class SettingManager
         var features = new LuaFeatures();
         var setting = Setting;
         features.ExcludeFolders.UnionWith(setting.Workspace.IgnoreDir);
+        features.ExcludeFiles.UnionWith(setting.Workspace.IgnoreFiles);
         features.DontIndexMaxFileSize = setting.Workspace.PreloadFileSize;
         features.ThirdPartyRoots.AddRange(setting.Workspace.Library);
         features.WorkspaceRoots.AddRange(setting.Workspace.WorkspaceRoots);

--- a/EmmyLua/EmmyLua.csproj
+++ b/EmmyLua/EmmyLua.csproj
@@ -12,6 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Glob" Version="1.1.9" />
       <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.0-preview.5.24306.7" />
     </ItemGroup>
     

--- a/EmmyLua/Resources/schema.json
+++ b/EmmyLua/Resources/schema.json
@@ -365,6 +365,18 @@
             ]
           }
         },
+        "ignoreFiles": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
         "library": {
           "type": [
             "array",

--- a/EmmyLua/Resources/schema.json
+++ b/EmmyLua/Resources/schema.json
@@ -365,7 +365,7 @@
             ]
           }
         },
-        "ignoreFiles": {
+        "ignoreGlobs": {
           "type": [
             "array",
             "null"


### PR DESCRIPTION
Feat:

1. add `ignoreGlobs` configuration.

Fix:

1. `ignoreDir` should not apply to internal lua std lib files.